### PR TITLE
util: Don't use gmtime() or localtime()

### DIFF
--- a/src/gridcoin/backup.cpp
+++ b/src/gridcoin/backup.cpp
@@ -9,6 +9,8 @@
 #include "util.h"
 #include "util/time.h"
 
+#include <boost/date_time/posix_time/posix_time.hpp>
+
 #include <string>
 
 using namespace GRC;
@@ -21,15 +23,9 @@ fs::path GRC::GetBackupPath()
 
 std::string GRC::GetBackupFilename(const std::string& basename, const std::string& suffix)
 {
-    time_t biTime;
-    struct tm * blTime;
-    time (&biTime);
-    blTime = localtime(&biTime);
-    char boTime[200];
-    strftime(boTime, sizeof(boTime), "%Y-%m-%dT%H-%M-%S", blTime);
     std::string sBackupFilename;
     fs::path rpath;
-    sBackupFilename = basename + "-" + std::string(boTime);
+    sBackupFilename = basename + "-" + std::string(FormatISO8601DateTime(GetTime()));
     if (!suffix.empty())
         sBackupFilename = sBackupFilename + "-" + suffix;
     rpath = GetBackupPath() / sBackupFilename;

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -8,6 +8,7 @@
 #include "util/time.h"
 #include "util/system.h"
 
+#include <boost/date_time/posix_time/posix_time.hpp>
 #include <boost/iostreams/stream.hpp>
 #include <boost/iostreams/copy.hpp>
 #include <boost/iostreams/filtering_stream.hpp>
@@ -501,4 +502,14 @@ bool BCLog::Logger::archive(bool fImmediate, fs::path pfile_out)
     {
         return false; // archive condition was not satisfied. Do nothing and return false.
     }
+}
+
+std::string DateTimeStrFormat(const char* pszFormat, int64_t nTime)
+{
+    // std::locale takes ownership of the pointer
+    std::locale loc(std::locale::classic(), new boost::posix_time::time_facet(pszFormat));
+    std::stringstream ss;
+    ss.imbue(loc);
+    ss << boost::posix_time::from_time_t(nTime);
+    return ss.str();
 }

--- a/src/logging.h
+++ b/src/logging.h
@@ -31,14 +31,7 @@ extern bool fLogIPs;
 // Unavoidable because this is in util.h.
 extern int64_t GetAdjustedTime();
 
-inline std::string DateTimeStrFormat(const char* pszFormat, int64_t nTime)
-{
-    time_t n = nTime;
-    struct tm* ptmTime = gmtime(&n);
-    char pszTime[200];
-    strftime(pszTime, sizeof(pszTime), pszFormat, ptmTime);
-    return pszTime;
-}
+std::string DateTimeStrFormat(const char* pszFormat, int64_t nTime);
 
 static const std::string strTimestampFormat = "%Y-%m-%d %H:%M:%S UTC";
 inline std::string DateTimeStrFormat(int64_t nTime)

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -1407,14 +1407,7 @@ UniValue scanforunspent(const UniValue& params, bool fHelp)
             // We will place this in wallet backups as a safer location then in main data directory
             fs::path exportpath;
 
-            time_t biTime;
-            struct tm * blTime;
-            time (&biTime);
-            blTime = localtime(&biTime);
-            char boTime[200];
-            strftime(boTime, sizeof(boTime), "%Y-%m-%dT%H-%M-%S", blTime);
-
-            std::string exportfile = params[0].get_str() + "-" + std::string(boTime) + "." + params[4].get_str();
+            std::string exportfile = params[0].get_str() + "-" + std::string(FormatISO8601DateTime(GetTime())) + "." + params[4].get_str();
 
             std::string backupdir = gArgs.GetArg("-backupdir", "");
 


### PR DESCRIPTION
`gmtime()` and `localtime()` are not thread safe.  Replace with safer alternatives.

> The time related functions such as gmtime fill data into a tm struct or char array in shared memory and then returns a pointer to that memory. If the function is called from multiple places in the same program, and especially if it is called from multiple threads in the same program, then the calls will overwrite each other's data.

In backup.cpp and rawtransaction.cpp we were using old code to get a formatted string of local time.  We can simply call our existing utility function `FormatISO8601DateTime` for this.

Ref: https://github.com/bitcoin/bitcoin/pull/4152/commits/3e8ac6af9a993e262d1160fb2e6e1e1f1d5d19f2