### PR TITLE
Implement TestArgsManager struct to support newer ArgsManager tests

### DIFF
--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -494,6 +494,11 @@ std::string ArgsManager::GetArg(const std::string& strArg, const std::string& st
     return value.isNull() ? strDefault : value.isFalse() ? "0" : value.isTrue() ? "1" : value.get_str();
 }
 
+int64_t ArgsManager::GetIntArg(const std::string& strArg, int64_t nDefault) const
+{
+    return GetArg(strArg, nDefault);
+}
+
 int64_t ArgsManager::GetArg(const std::string& strArg, int64_t nDefault) const
 {
     const util::SettingsValue value = GetSetting(strArg);

--- a/src/util/system.h
+++ b/src/util/system.h
@@ -270,6 +270,15 @@ public:
     int64_t GetArg(const std::string& strArg, int64_t nDefault) const;
 
     /**
+     * Return integer argument or default value (alias for GetArg used in newer Bitcoin code)
+     *
+     * @param strArg Argument to get (e.g. "-foo")
+     * @param nDefault (e.g. 1)
+     * @return command-line argument (0 if invalid number) or default value
+     */
+    int64_t GetIntArg(const std::string& strArg, int64_t nDefault) const;
+
+    /**
      * Return boolean argument or default value
      *
      * @param strArg Argument to get (e.g. "-foo")


### PR DESCRIPTION
This also includes reserved (commented out code) we need to turn on when we port over more of the Chain testing stuff